### PR TITLE
ci: バージョン付きイメージtag + README .env を .env.example に一元化

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - v*.*.*
   workflow_dispatch:
 
 env:
@@ -16,17 +18,17 @@ jobs:
     permissions:
       contents: read
       packages: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       # ディスク容量を大幅に確保
       - name: Free disk space
         run: |
           echo "=== Before cleanup ==="
           df -h
-          
+
           # 大容量の不要ツールを削除
           sudo rm -rf /usr/share/dotnet          # ~17GB
           sudo rm -rf /opt/ghc                   # ~8.8GB
@@ -34,54 +36,69 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"   # ~1.7GB
           sudo rm -rf /usr/local/lib/android     # ~12GB
           sudo rm -rf /usr/share/swift           # ~1.2GB
-          
+
           # APTキャッシュクリア
           sudo apt-get clean
-          
+
           # Dockerクリーンアップ
           docker system prune -af
-          
+
           echo "=== After cleanup ==="
           df -h
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Extract metadata
-        id: meta
+
+      # 画像ごとに metadata を生成する。
+      # - main への push: latest + sha
+      # - vX.Y.Z タグの push: X.Y.Z + X.Y + sha（バージョン付きイメージ）
+      - name: Extract metadata (graphiti-ingest)
+        id: meta_ingest
         uses: docker/metadata-action@v5
         with:
-          images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/graphiti-ingest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/graphiti-mcp-server
-      
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/graphiti-ingest
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Extract metadata (graphiti-mcp-server)
+        id: meta_mcp
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/graphiti-mcp-server
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
       - name: Build and push graphiti-ingest
         uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/graphiti-ingest:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/graphiti-ingest:${{ github.sha }}
+          tags: ${{ steps.meta_ingest.outputs.tags }}
+          labels: ${{ steps.meta_ingest.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      
+
       - name: Build and push graphiti-mcp-server
         uses: docker/build-push-action@v5
         with:
           context: ./mcp_server
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/graphiti-mcp-server:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/graphiti-mcp-server:${{ github.sha }}
+          tags: ${{ steps.meta_mcp.outputs.tags }}
+          labels: ${{ steps.meta_mcp.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -165,34 +165,12 @@ const addResult = await mcp.call_tool("add_memory", {
 
 ## 設定
 
-### .envファイルの例
+環境変数の一覧と説明・既定値は [.env.example](.env.example) を参照してください（設定はこのファイルで一元管理しています）。
 
-```ini
-# Neo4jデータベース
-NEO4J_URI=bolt://localhost:7687 # docker composeでは不使用です。定義に合わせて上書きされます。
-NEO4J_USER=neo4j
-NEO4J_PASSWORD=password
-
-# LLMモデル
-LLM_MODEL_URL=https://api.openai.com/v1
-LLM_MODEL_NAME=gpt-4o-mini
-LLM_MODEL_KEY=your_openai_api_key
-
-# Rerankモデル
-RERANK_MODEL_NAME=gpt-4.1-nano
-
-# Embeddingモデル
-EMBEDDING_MODEL_URL=http://host.docker.internal:11434/v1
-EMBEDDING_MODEL_NAME=kun432/cl-nagoya-ruri-large:latest
-EMBEDDING_MODEL_KEY=dummy
-
-# テナント識別子
-GROUP_ID=default
-
-# チャンク設定（オプション）
-CHUNK_SIZE_MAX=2000
-CHUNK_SIZE_MIN=200
-CHUNK_OVERLAP=0
+```bash
+# .env.example をコピーして編集
+cp .env.example .env
+vi .env
 ```
 
 ## 既知の課題


### PR DESCRIPTION
## 変更
- **イメージのバージョンtag化**: `docker-publish.yml` に `v*.*.*` タグトリガーを追加し、metadata-action(semver) でタグ push 時に `X.Y.Z` / `X.Y` のバージョン付きイメージを公開。main push は従来どおり `latest` + `sha`。
- **README 一元化**: `.envファイルの例` のインライン ini を削除し、[.env.example](.env.example) へのリンクに集約。

## 検証
- `make check`: lint クリーン / 82 passed
- YAML パース OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)